### PR TITLE
Fix mqtt examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ temperature | unit, value | ```{"unit":"°C", "value":"24"}``` |
 sensor:
   - platform: mqtt
     state_topic: "voicepanel/sensor/battery"
-    name: "Alarm Panel Battery Level"
+    name: "Voice Panel Battery Level"
     unit_of_measurement: "%"
     value_template: '{{ value_json.value }}'
     
@@ -334,19 +334,19 @@ sensor:
 
   - platform: mqtt
     state_topic: "voicepanel/sensor/light"
-    name: "Alarm Panel Light Level"
+    name: "Voice Panel Light Level"
     unit_of_measurement: "lx"
     value_template: '{{ value_json.value }}'
     
   - platform: mqtt
     state_topic: "voicepanel/sensor/magneticField"
-    name: "Alarm Panel Magnetic Field"
+    name: "Voice Panel Magnetic Field"
     unit_of_measurement: "uT"
     value_template: '{{ value_json.value }}'
 
   - platform: mqtt
     state_topic: "voicepanel/sensor/pressure"
-    name: "Alarm Panel Pressure"
+    name: "Voice Panel Pressure"
     unit_of_measurement: "hPa"
     value_template: '{{ value_json.value }}'
 ```

--- a/README.md
+++ b/README.md
@@ -238,11 +238,11 @@ You can also use MQTT to publish the weather to the Voice Panel application, whi
   alias: MQTT Weather
   trigger:
   - minutes: '/15'
-    platform: time
+    platform: time_pattern
   condition: []
   action:
   - data:
-      payload_template: {% raw %}'{''weather'':{''summary'':''{{states(''sensor.dark_sky_summary'')}}'',''precipitation'':''{{states(''sensor.dark_sky_precip_probability'')}}'',''icon'':''{{states(''sensor.dark_sky_icon'')}}'',''temperature'':''{{states(''sensor.dark_sky_apparent_temperature'')}}'',''units'':''{{states.sensor.dark_sky_apparent_temperature.attributes.unit_of_measurement}}''}}'{% endraw %}
+      payload_template: {% raw %}"{'weather':{'summary':'{{states('sensor.dark_sky_summary')}}','precipitation':'{{states('sensor.dark_sky_precip_probability')}}','icon':'{{states('sensor.dark_sky_icon')}}','temperature':'{{states('sensor.dark_sky_apparent_temperature')}}','units':'{{states.sensor.dark_sky_apparent_temperature.attributes.unit_of_measurement}}'}}"{% endraw %}
       topic: voicepanel/command
       retain: true
     service: mqtt.publish
@@ -251,7 +251,7 @@ You can also use MQTT to publish the weather to the Voice Panel application, whi
 The resulting payload will look like this:
 
 ```
-{"topic": "voicepanel/command","payload":"{'weather':{'summary':'Partly Cloudy','precipitation':'0','icon':'partly-cloudy-day','temperature':'22.5','units':'°C'}}
+{"topic": "voicepanel/command","payload":"{'weather':{'summary':'Partly Cloudy','precipitation':'0','icon':'partly-cloudy-day','temperature':'22.5','units':'°C'}}"}
 ```
 
 ### MQTT Day/Night Mode

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Similar to how weather works, you can control the Voice Panel to display the day
   alias: MQTT Sun
   trigger:
   - minutes: '/5'
-    platform: time
+    platform: time_pattern
   condition: []
   action:
   - data:
@@ -278,7 +278,7 @@ The resulting payload will look like this:
 ```
 {
   "payload": "{'sun':'below_horizon'}",
-  "topic": "alarmpanel/command"
+  "topic": "voicepanel/command"
 }
 ```
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,9 +182,9 @@
     <string name="preference_title_alert">Alert Notifications</string>
     <string name="preference_title_system_notifications">System Notifications</string>
     <string name="preference_title_weather">Weather MQTT</string>
-    <string name="preference_summary_alert">Example format for the message topic and payload to display alert dialog: \n\n"{\"topic\":\"alarmpanel/command\", \"payload\":\"{\"alert\":\"Hello!\"}\"}"</string>
+    <string name="preference_summary_alert">Example format for the message topic and payload to display alert dialog: \n\n"{\"topic\":\"voicepanel/command\", \"payload\":\"{\"alert\":\"Hello!\"}\"}"</string>
     <string name="preference_tts">TTS Notifications</string>
-    <string name="preference_tts_topic_summary">Example format for the message topic and payload to be spoken: \n\n"{\"topic\":\"alarmpanel/command\", \"payload\":\"{\"speak\":\"Hello!\"}\"}"</string>
+    <string name="preference_tts_topic_summary">Example format for the message topic and payload to be spoken: \n\n"{\"topic\":\"voicepanel/command\", \"payload\":\"{\"speak\":\"Hello!\"}\"}"</string>
     <string name="preference_camera">Camera</string>
     <string name="preference_camera_title">Camera Capture</string>
     <string name="preference_camera_summary">Use the camera to capture an image and send it when the alarm is disabled using Telegram.</string>
@@ -198,7 +198,7 @@
     <string name="pref_fullscreen_description">Display application in fullscreen mode.</string>
     <string name="pref_face_detection_summary">Detects faces using the device\'s camera.</string>
     <string name="pref_mjpeg_streaming_summary">Use the device camera as a live MJPEG stream.</string>
-    <string name="summary_notification_topic">Example format for the message topic and payload: \n\n"{\"topic\":\"alarmpanel/command\", \"payload\":\"{\"notification\":\"Hello!\"}\"}"</string>
+    <string name="summary_notification_topic">Example format for the message topic and payload: \n\n"{\"topic\":\"voicepanel/command\", \"payload\":\"{\"notification\":\"Hello!\"}\"}"</string>
     <string name="summary_weather_topic">Example format for the command topic and payload for weather data: \n\n"{\"topic\": \"voicepanel/command\",\"payload\":\"{'weather':{'summary':'Partly Cloudy','precipitation':'0','icon':'partly-cloudy-day','temperature':'22.5','units':'°C'}}\"}"</string>
     <string name="summary_setting_mqtt_basetopic">Identifier to receive MQTT commands for this panel. Each panel should have a unique identifier.</string>
     <string name="title_voice_assistant">Voice Assistant</string>


### PR DESCRIPTION
* Sun MQTT, Weather MQTT examples referred to `time` platform, should be `time_pattern`
* Output of Sun MQTT referred to alarmpanel, should be voicepanel.
* Weather MQTT payload_pattern escaped using single quotes, should be escaped like Sun MQTT.
* Examples referred to Alarm Panel, should be Voice Panel.